### PR TITLE
Fix #36

### DIFF
--- a/spannedgridlayoutmanager/src/main/java/com/arasthel/spannedgridlayoutmanager/SpannedGridLayoutManager.kt
+++ b/spannedgridlayoutmanager/src/main/java/com/arasthel/spannedgridlayoutmanager/SpannedGridLayoutManager.kt
@@ -191,7 +191,7 @@ open class SpannedGridLayoutManager(val orientation: Orientation,
     //==============================================================================================
 
     override fun onLayoutChildren(recycler: RecyclerView.Recycler, state: RecyclerView.State) {
-
+        if (childCount <= 0 && scroll != 0) scroll = 0
         rectsHelper = RectsHelper(this, orientation)
 
         layoutStart = getPaddingStartForOrientation()

--- a/spannedgridlayoutmanager/src/main/java/com/arasthel/spannedgridlayoutmanager/SpannedGridLayoutManager.kt
+++ b/spannedgridlayoutmanager/src/main/java/com/arasthel/spannedgridlayoutmanager/SpannedGridLayoutManager.kt
@@ -191,7 +191,7 @@ open class SpannedGridLayoutManager(val orientation: Orientation,
     //==============================================================================================
 
     override fun onLayoutChildren(recycler: RecyclerView.Recycler, state: RecyclerView.State) {
-        if (childCount <= 0 && scroll != 0) scroll = 0
+        if (childCount == 0 && scroll != 0) scroll = 0
         rectsHelper = RectsHelper(this, orientation)
 
         layoutStart = getPaddingStartForOrientation()


### PR DESCRIPTION
issue #36 


![2018-11-29 2 36 02](https://user-images.githubusercontent.com/28793321/49202453-fa788f00-f3e7-11e8-86cb-40b4c00a090e.png)

![2018-11-29 2 35 59](https://user-images.githubusercontent.com/28793321/49202455-fcdae900-f3e7-11e8-8f0c-bb0eac76d665.png)

When adding data to the adapter for the first time after receiving an asynchronous request, the scroll value is set to a different value which was supposed to be zero.
